### PR TITLE
Parameter to use relativ outputDir

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Below are the parameters that can be used to configure the build:
 | `keepJava`    | `boolean`        | Keep temporary files after compiling. Default value: `false`                                  |
 | `validateXml` | `boolean`        | Validate source files before compiling. Default value: `true`                                 |
 | `verbose`     | `boolean`        | Verbose plugin outpout. Default value: `false`                                                |
+| `useRelativeOutDir`     | `boolean`        | The outDir is relative to java classpath. Default value: `false`                                                |
 | `classpath`   | `Iterable<File>` | Extra elements to add to the classpath when compile. Default value: `[]`                      |
 
 ### Example
@@ -85,6 +86,7 @@ Below is a complete example, with default values:
         keepJava = false
         validateXml = true
         verbose = false
+        useRelativeOutDir = false
         classpath = []
     }
 

--- a/src/main/groovy/com/github/gmazelier/plugins/JasperReportsExtension.groovy
+++ b/src/main/groovy/com/github/gmazelier/plugins/JasperReportsExtension.groovy
@@ -4,22 +4,22 @@ import org.gradle.api.Project
 
 class JasperReportsExtension {
 
-    Iterable<File> classpath = []
-    File srcDir = new File('src/main/jasperreports')
-    File tmpDir = new File("${project.buildDir}/jasperreports")
-    File outDir = new File("${project.buildDir}/classes/main")
-    String srcExt = '.jrxml'
-    String outExt = '.jasper'
-    String compiler = 'net.sf.jasperreports.engine.design.JRJdtCompiler'
-    boolean keepJava = false
-    boolean validateXml = true
-    boolean verbose = false
-    boolean useRelativeOutDir = false
+	Iterable<File> classpath = []
+	File srcDir = new File('src/main/jasperreports')
+	File tmpDir = new File("${project.buildDir}/jasperreports")
+	File outDir = new File("${project.buildDir}/classes/main")
+	String srcExt = '.jrxml'
+	String outExt = '.jasper'
+	String compiler = 'net.sf.jasperreports.engine.design.JRJdtCompiler'
+	boolean keepJava = false
+	boolean validateXml = true
+	boolean verbose = false
+	boolean useRelativeOutDir = false
 
-    private Project project
+	private Project project
 
-    JasperReportsExtension(Project project) {
-        this.project = project
-    }
+	JasperReportsExtension(Project project) {
+		this.project = project
+	}
 
 }

--- a/src/main/groovy/com/github/gmazelier/plugins/JasperReportsExtension.groovy
+++ b/src/main/groovy/com/github/gmazelier/plugins/JasperReportsExtension.groovy
@@ -1,23 +1,25 @@
 package com.github.gmazelier.plugins
+
 import org.gradle.api.Project
 
 class JasperReportsExtension {
 
-  Iterable<File> classpath = []
-	File srcDir = new File('src/main/jasperreports')
-	File tmpDir = new File("${project.buildDir }/jasperreports")
-	File outDir = new File("${project.buildDir }/classes/main")
-	String srcExt = '.jrxml'
-	String outExt = '.jasper'
-	String compiler = 'net.sf.jasperreports.engine.design.JRJdtCompiler'
-	boolean keepJava = false
-	boolean validateXml = true
-	boolean verbose = false
+    Iterable<File> classpath = []
+    File srcDir = new File('src/main/jasperreports')
+    File tmpDir = new File("${project.buildDir}/jasperreports")
+    File outDir = new File("${project.buildDir}/classes/main")
+    String srcExt = '.jrxml'
+    String outExt = '.jasper'
+    String compiler = 'net.sf.jasperreports.engine.design.JRJdtCompiler'
+    boolean keepJava = false
+    boolean validateXml = true
+    boolean verbose = false
+    boolean usePackageDir = false
 
-	private Project project
+    private Project project
 
-	JasperReportsExtension(Project project)  {
-		this.project = project
-	}
+    JasperReportsExtension(Project project) {
+        this.project = project
+    }
 
 }

--- a/src/main/groovy/com/github/gmazelier/plugins/JasperReportsExtension.groovy
+++ b/src/main/groovy/com/github/gmazelier/plugins/JasperReportsExtension.groovy
@@ -14,7 +14,7 @@ class JasperReportsExtension {
     boolean keepJava = false
     boolean validateXml = true
     boolean verbose = false
-    boolean usePackageDir = false
+    boolean useRelativeOutDir = false
 
     private Project project
 

--- a/src/main/groovy/com/github/gmazelier/plugins/JasperReportsPlugin.groovy
+++ b/src/main/groovy/com/github/gmazelier/plugins/JasperReportsPlugin.groovy
@@ -7,46 +7,46 @@ import org.gradle.api.Project
 
 class JasperReportsPlugin implements Plugin<Project> {
 
-	@Override
-	void apply(Project project) {
-		project.extensions.create("jasperreports", JasperReportsExtension, project)
-		def extension = project.jasperreports as JasperReportsExtension
+    @Override
+    void apply(Project project) {
+        project.extensions.create("jasperreports", JasperReportsExtension, project)
+        def extension = project.jasperreports as JasperReportsExtension
 
-		def preCompileTask = project.task(
-				'prepareReportsCompilation',
-				description: 'Configure JasperReports compiler and environment.',
-				type: JasperReportsPreCompile
-		) as JasperReportsPreCompile
+        def preCompileTask = project.task(
+                'prepareReportsCompilation',
+                description: 'Configure JasperReports compiler and environment.',
+                type: JasperReportsPreCompile
+        ) as JasperReportsPreCompile
 
-		def compileTask = project.task(
-				'compileAllReports',
-				description: 'Compile JasperReports design source files.',
-				group: 'jasperReports',
-				dependsOn: 'prepareReportsCompilation',
-				type: JasperReportsCompile
-		) as JasperReportsCompile
+        def compileTask = project.task(
+                'compileAllReports',
+                description: 'Compile JasperReports design source files.',
+                group: 'jasperReports',
+                dependsOn: 'prepareReportsCompilation',
+                type: JasperReportsCompile
+        ) as JasperReportsCompile
 
-		project.afterEvaluate {
-			// Precompile task
-			preCompileTask.srcDir = extension.srcDir
-			preCompileTask.tmpDir = extension.tmpDir
-			preCompileTask.outDir = extension.outDir
-			preCompileTask.srcExt = extension.srcExt
-			preCompileTask.outExt = extension.outExt
-			preCompileTask.compiler = extension.compiler
-			preCompileTask.keepJava = extension.keepJava
-			preCompileTask.validateXml = extension.validateXml
-			preCompileTask.verbose = extension.verbose
-            preCompileTask.usePackageDir = extension.usePackageDir
-			// Compile task
-			compileTask.classpath = project.jasperreports.classpath
-			compileTask.srcDir = project.jasperreports.srcDir
-			compileTask.outDir = project.jasperreports.outDir
-			compileTask.srcExt = project.jasperreports.srcExt
-			compileTask.outExt = project.jasperreports.outExt
-			compileTask.verbose = project.jasperreports.verbose
-            compileTask.usePackageDir = project.jasperreports.usePackageDir
-		}
-	}
+        project.afterEvaluate {
+            // Precompile task
+            preCompileTask.srcDir = extension.srcDir
+            preCompileTask.tmpDir = extension.tmpDir
+            preCompileTask.outDir = extension.outDir
+            preCompileTask.srcExt = extension.srcExt
+            preCompileTask.outExt = extension.outExt
+            preCompileTask.compiler = extension.compiler
+            preCompileTask.keepJava = extension.keepJava
+            preCompileTask.validateXml = extension.validateXml
+            preCompileTask.verbose = extension.verbose
+            preCompileTask.useRelativeOutDir = extension.useRelativeOutDir
+            // Compile task
+            compileTask.classpath = project.jasperreports.classpath
+            compileTask.srcDir = project.jasperreports.srcDir
+            compileTask.outDir = project.jasperreports.outDir
+            compileTask.srcExt = project.jasperreports.srcExt
+            compileTask.outExt = project.jasperreports.outExt
+            compileTask.verbose = project.jasperreports.verbose
+            compileTask.useRelativeOutDir = project.jasperreports.useRelativeOutDir
+        }
+    }
 
 }

--- a/src/main/groovy/com/github/gmazelier/plugins/JasperReportsPlugin.groovy
+++ b/src/main/groovy/com/github/gmazelier/plugins/JasperReportsPlugin.groovy
@@ -37,6 +37,7 @@ class JasperReportsPlugin implements Plugin<Project> {
 			preCompileTask.keepJava = extension.keepJava
 			preCompileTask.validateXml = extension.validateXml
 			preCompileTask.verbose = extension.verbose
+            preCompileTask.usePackageDir = extension.usePackageDir
 			// Compile task
 			compileTask.classpath = project.jasperreports.classpath
 			compileTask.srcDir = project.jasperreports.srcDir
@@ -44,6 +45,7 @@ class JasperReportsPlugin implements Plugin<Project> {
 			compileTask.srcExt = project.jasperreports.srcExt
 			compileTask.outExt = project.jasperreports.outExt
 			compileTask.verbose = project.jasperreports.verbose
+            compileTask.usePackageDir = project.jasperreports.usePackageDir
 		}
 	}
 

--- a/src/main/groovy/com/github/gmazelier/plugins/JasperReportsPlugin.groovy
+++ b/src/main/groovy/com/github/gmazelier/plugins/JasperReportsPlugin.groovy
@@ -7,46 +7,46 @@ import org.gradle.api.Project
 
 class JasperReportsPlugin implements Plugin<Project> {
 
-    @Override
-    void apply(Project project) {
-        project.extensions.create("jasperreports", JasperReportsExtension, project)
-        def extension = project.jasperreports as JasperReportsExtension
+	@Override
+	void apply(Project project) {
+		project.extensions.create("jasperreports", JasperReportsExtension, project)
+		def extension = project.jasperreports as JasperReportsExtension
 
-        def preCompileTask = project.task(
-                'prepareReportsCompilation',
-                description: 'Configure JasperReports compiler and environment.',
-                type: JasperReportsPreCompile
-        ) as JasperReportsPreCompile
+		def preCompileTask = project.task(
+				'prepareReportsCompilation',
+				description: 'Configure JasperReports compiler and environment.',
+				type: JasperReportsPreCompile
+		) as JasperReportsPreCompile
 
-        def compileTask = project.task(
-                'compileAllReports',
-                description: 'Compile JasperReports design source files.',
-                group: 'jasperReports',
-                dependsOn: 'prepareReportsCompilation',
-                type: JasperReportsCompile
-        ) as JasperReportsCompile
+		def compileTask = project.task(
+				'compileAllReports',
+				description: 'Compile JasperReports design source files.',
+				group: 'jasperReports',
+				dependsOn: 'prepareReportsCompilation',
+				type: JasperReportsCompile
+		) as JasperReportsCompile
 
-        project.afterEvaluate {
-            // Precompile task
-            preCompileTask.srcDir = extension.srcDir
-            preCompileTask.tmpDir = extension.tmpDir
-            preCompileTask.outDir = extension.outDir
-            preCompileTask.srcExt = extension.srcExt
-            preCompileTask.outExt = extension.outExt
-            preCompileTask.compiler = extension.compiler
-            preCompileTask.keepJava = extension.keepJava
-            preCompileTask.validateXml = extension.validateXml
-            preCompileTask.verbose = extension.verbose
-            preCompileTask.useRelativeOutDir = extension.useRelativeOutDir
-            // Compile task
-            compileTask.classpath = project.jasperreports.classpath
-            compileTask.srcDir = project.jasperreports.srcDir
-            compileTask.outDir = project.jasperreports.outDir
-            compileTask.srcExt = project.jasperreports.srcExt
-            compileTask.outExt = project.jasperreports.outExt
-            compileTask.verbose = project.jasperreports.verbose
-            compileTask.useRelativeOutDir = project.jasperreports.useRelativeOutDir
-        }
-    }
+		project.afterEvaluate {
+			// Precompile task
+			preCompileTask.srcDir = extension.srcDir
+			preCompileTask.tmpDir = extension.tmpDir
+			preCompileTask.outDir = extension.outDir
+			preCompileTask.srcExt = extension.srcExt
+			preCompileTask.outExt = extension.outExt
+			preCompileTask.compiler = extension.compiler
+			preCompileTask.keepJava = extension.keepJava
+			preCompileTask.validateXml = extension.validateXml
+			preCompileTask.verbose = extension.verbose
+			preCompileTask.useRelativeOutDir = extension.useRelativeOutDir
+			// Compile task
+			compileTask.classpath = project.jasperreports.classpath
+			compileTask.srcDir = project.jasperreports.srcDir
+			compileTask.outDir = project.jasperreports.outDir
+			compileTask.srcExt = project.jasperreports.srcExt
+			compileTask.outExt = project.jasperreports.outExt
+			compileTask.verbose = project.jasperreports.verbose
+			compileTask.useRelativeOutDir = project.jasperreports.useRelativeOutDir
+		}
+	}
 
 }

--- a/src/main/groovy/com/github/gmazelier/tasks/JasperReportsCompile.groovy
+++ b/src/main/groovy/com/github/gmazelier/tasks/JasperReportsCompile.groovy
@@ -10,97 +10,97 @@ import static groovyx.gpars.GParsPool.withPool
 
 class JasperReportsCompile extends DefaultTask {
 
-    @InputFiles
-    Iterable<File> classpath
-    @InputDirectory
-    def File srcDir
-    @OutputDirectory
-    def File outDir
-    @Input
-    def String srcExt
-    @Input
-    def String outExt
-    def boolean verbose
-    def boolean useRelativeOutDir
-    def log = getLogger()
+	@InputFiles
+	Iterable<File> classpath
+	@InputDirectory
+	def File srcDir
+	@OutputDirectory
+	def File outDir
+	@Input
+	def String srcExt
+	@Input
+	def String outExt
+	def boolean verbose
+	def boolean useRelativeOutDir
+	def log = getLogger()
 
-    @TaskAction
-    void execute(IncrementalTaskInputs inputs) {
+	@TaskAction
+	void execute(IncrementalTaskInputs inputs) {
 
-        def dependencies = classpath.collect { dependency ->
-            dependency?.toURI()?.toURL()
-        }
-        if (verbose) log.lifecycle "Additional classpath: ${dependencies}"
+		def dependencies = classpath.collect { dependency ->
+			dependency?.toURI()?.toURL()
+		}
+		if (verbose) log.lifecycle "Additional classpath: ${dependencies}"
 
-        def compilationTasks = []
-        inputs.outOfDate { change ->
-            if (change.file.name.endsWith(srcExt))
-                compilationTasks << [src: change.file, out: outputFile(change.file), deps: dependencies]
-        }
-        inputs.removed { change ->
-            if (verbose) log.lifecycle "Removed file ${change.file.name}"
-            def fileToRemove = outputFile(change.file)
-            fileToRemove.delete()
-        }
+		def compilationTasks = []
+		inputs.outOfDate { change ->
+			if (change.file.name.endsWith(srcExt))
+				compilationTasks << [src: change.file, out: outputFile(change.file), deps: dependencies]
+		}
+		inputs.removed { change ->
+			if (verbose) log.lifecycle "Removed file ${change.file.name}"
+			def fileToRemove = outputFile(change.file)
+			fileToRemove.delete()
+		}
 
-        def start = System.currentTimeMillis()
+		def start = System.currentTimeMillis()
 
-        def results = []
-        withPool {
-            results = compilationTasks.collectParallel { task ->
-                def src = task['src'] as File
-                def out = task['out'] as File
-                def deps = task['deps']
+		def results = []
+		withPool {
+			results = compilationTasks.collectParallel { task ->
+				def src = task['src'] as File
+				def out = task['out'] as File
+				def deps = task['deps']
 
-                if (verbose) log.lifecycle "Compiling file ${src.name}"
+				if (verbose) log.lifecycle "Compiling file ${src.name}"
 
-                try {
-                    // Configure class loader with addtional dependencies
-                    ClassLoader originalLoader = Thread.currentThread().getContextClassLoader()
-                    URLClassLoader loader = new URLClassLoader(deps as URL[], originalLoader)
-                    Thread.currentThread().setContextClassLoader loader
-                    // Compile report
-                    JasperCompileManager.compileReportToFile src.absolutePath, out.absolutePath
-                    // Restore class loader
-                    Thread.currentThread().setContextClassLoader originalLoader
-                } catch (any) {
-                    return [name: src.name, success: false, exception: any]
-                }
-                [name: src.name, success: true]
-            }
-        }
+				try {
+					// Configure class loader with addtional dependencies
+					ClassLoader originalLoader = Thread.currentThread().getContextClassLoader()
+					URLClassLoader loader = new URLClassLoader(deps as URL[], originalLoader)
+					Thread.currentThread().setContextClassLoader loader
+					// Compile report
+					JasperCompileManager.compileReportToFile src.absolutePath, out.absolutePath
+					// Restore class loader
+					Thread.currentThread().setContextClassLoader originalLoader
+				} catch (any) {
+					return [name: src.name, success: false, exception: any]
+				}
+				[name: src.name, success: true]
+			}
+		}
 
-        def stop = System.currentTimeMillis()
+		def stop = System.currentTimeMillis()
 
-        def failures = results.findAll { !it['success'] }
-        if (failures) throw new GradleException(failureMessage(failures))
+		def failures = results.findAll { !it['success'] }
+		if (failures) throw new GradleException(failureMessage(failures))
 
-        log.lifecycle "${results.size()} designs compiled in ${stop - start} ms"
-    }
+		log.lifecycle "${results.size()} designs compiled in ${stop - start} ms"
+	}
 
-    def File outputFile(File src) {
+	def File outputFile(File src) {
 
-        if (useRelativeOutDir) {
-            def srcPackagePath = src.absolutePath.replaceAll(srcDir.absolutePath, "")
-            def outDirPath = outDir.absolutePath + srcPackagePath.replaceAll(src.name, "")
-            outDir = new File(outDirPath)
-            if (!outDir.isDirectory()) {
-                if (verbose) log.lifecycle "Create outDir: ${outDir.absolutePath}"
-                outDir.mkdirs()
-            }
-        }
+		if (useRelativeOutDir) {
+			def srcPackagePath = src.absolutePath.replaceAll(srcDir.absolutePath, "")
+			def outDirPath = outDir.absolutePath + srcPackagePath.replaceAll(src.name, "")
+			outDir = new File(outDirPath)
+			if (!outDir.isDirectory()) {
+				if (verbose) log.lifecycle "Create outDir: ${outDir.absolutePath}"
+				outDir.mkdirs()
+			}
+		}
 
-        new File(outDir, src.name.replaceAll(srcExt, outExt))
+		new File(outDir, src.name.replaceAll(srcExt, outExt))
 
-    }
+	}
 
-    def failureMessage = { List failures ->
-        def stringBuilder = new StringBuilder()
-        stringBuilder.append "Could not compile ${failures.size()} designs:\n"
-        failures.each { failure ->
-            stringBuilder.append "\t[${failure['name']}] ${failure['exception'].message}\n"
-        }
-        stringBuilder.toString()
-    }
+	def failureMessage = { List failures ->
+		def stringBuilder = new StringBuilder()
+		stringBuilder.append "Could not compile ${failures.size()} designs:\n"
+		failures.each { failure ->
+			stringBuilder.append "\t[${failure['name']}] ${failure['exception'].message}\n"
+		}
+		stringBuilder.toString()
+	}
 
 }

--- a/src/main/groovy/com/github/gmazelier/tasks/JasperReportsCompile.groovy
+++ b/src/main/groovy/com/github/gmazelier/tasks/JasperReportsCompile.groovy
@@ -1,92 +1,119 @@
 package com.github.gmazelier.tasks
 
-import static groovyx.gpars.GParsPool.withPool
-
 import net.sf.jasperreports.engine.JasperCompileManager
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
-import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputDirectory
-import org.gradle.api.tasks.InputFiles
-import org.gradle.api.tasks.OutputDirectory
-import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.*
 import org.gradle.api.tasks.incremental.IncrementalTaskInputs
+
+import static groovyx.gpars.GParsPool.withPool
 
 class JasperReportsCompile extends DefaultTask {
 
-	@InputFiles Iterable<File> classpath
-	@InputDirectory def File srcDir
-	@OutputDirectory def File outDir
-	@Input def String srcExt
-	@Input def String outExt
-	def boolean verbose
+    @InputFiles
+    Iterable<File> classpath
+    @InputDirectory
+    def File srcDir
+    @OutputDirectory
+    def File outDir
+    @Input
+    def String srcExt
+    @Input
+    def String outExt
+    def boolean verbose
+    def boolean usePackageDir
+    def log = getLogger()
 
-	@TaskAction
-	void execute(IncrementalTaskInputs inputs) {
-		def log = getLogger()
+    @TaskAction
+    void execute(IncrementalTaskInputs inputs) {
 
-		def dependencies = classpath.collect { dependency ->
-			dependency?.toURI()?.toURL()
-		}
-    if (verbose) log.lifecycle "Additional classpath: ${dependencies}"
+        def dependencies = classpath.collect { dependency ->
+            dependency?.toURI()?.toURL()
+        }
+        if (verbose) log.lifecycle "Additional classpath: ${dependencies}"
 
-		def compilationTasks = []
-		inputs.outOfDate { change ->
-			if (change.file.name.endsWith(srcExt))
-				compilationTasks << [src: change.file, out: outputFile(change.file), deps: dependencies]
-		}
-		inputs.removed { change ->
-			if (verbose) log.lifecycle "Removed file ${change.file.name}"
-			def fileToRemove = outputFile(change.file)
-			fileToRemove.delete()
-		}
+        def compilationTasks = []
+        inputs.outOfDate { change ->
+            if (change.file.name.endsWith(srcExt))
+                compilationTasks << [src: change.file, out: outputFile(change.file), deps: dependencies]
+        }
+        inputs.removed { change ->
+            if (verbose) log.lifecycle "Removed file ${change.file.name}"
+            def fileToRemove = outputFile(change.file)
+            fileToRemove.delete()
+        }
 
-		def start = System.currentTimeMillis()
+        def start = System.currentTimeMillis()
 
-		def results = []
-		withPool {
-			results = compilationTasks.collectParallel { task ->
-				def src = task['src'] as File
-				def out = task['out'] as File
-				def deps = task['deps']
+        def results = []
+        withPool {
+            results = compilationTasks.collectParallel { task ->
+                def src = task['src'] as File
+                def out = task['out'] as File
+                def deps = task['deps']
 
-				if (verbose) log.lifecycle "Compiling file ${src.name}"
-				
-				try {
-					// Configure class loader with addtional dependencies
-					ClassLoader originalLoader = Thread.currentThread().getContextClassLoader()
-					URLClassLoader loader = new URLClassLoader(deps as URL[], originalLoader)
-					Thread.currentThread().setContextClassLoader loader
-					// Compile report
-					JasperCompileManager.compileReportToFile src.absolutePath, out.absolutePath
-					// Restore class loader
-					Thread.currentThread().setContextClassLoader originalLoader
-				} catch (any) {
-					return [name: src.name, success: false, exception: any]
-				}
-				[name: src.name, success: true]
-			}
-		}
+                if (verbose) log.lifecycle "Compiling file ${src.name}"
 
-		def stop = System.currentTimeMillis()
+                try {
+                    // Configure class loader with addtional dependencies
+                    ClassLoader originalLoader = Thread.currentThread().getContextClassLoader()
+                    URLClassLoader loader = new URLClassLoader(deps as URL[], originalLoader)
+                    Thread.currentThread().setContextClassLoader loader
+                    // Compile report
+                    JasperCompileManager.compileReportToFile src.absolutePath, out.absolutePath
+                    // Restore class loader
+                    Thread.currentThread().setContextClassLoader originalLoader
+                } catch (any) {
+                    return [name: src.name, success: false, exception: any]
+                }
+                [name: src.name, success: true]
+            }
+        }
 
-		def failures = results.findAll { !it['success'] }
-		if (failures) throw new GradleException(failureMessage(failures))
+        def stop = System.currentTimeMillis()
 
-		log.lifecycle "${results.size()} designs compiled in ${stop - start} ms"
-	}
+        def failures = results.findAll { !it['success'] }
+        if (failures) throw new GradleException(failureMessage(failures))
 
-	def File outputFile(File src) {
-		new File(outDir, src.name.replaceAll(srcExt, outExt))
-	}
+        log.lifecycle "${results.size()} designs compiled in ${stop - start} ms"
+    }
 
-	def failureMessage = { List failures ->
-		def stringBuilder = new StringBuilder()
-		stringBuilder.append "Could not compile ${failures.size()} designs:\n"
-		failures.each { failure ->
-			stringBuilder.append "\t[${failure['name']}] ${failure['exception'].message}\n"
-		}
-		stringBuilder.toString()
-	}
+    def File outputFile(File src) {
+
+        if (usePackageDir) {
+            def srcPackagePath = src.absolutePath.replaceAll(srcDir.absolutePath, "")
+            def outDirPath = outDir.absolutePath + srcPackagePath.replaceAll(src.name, "")
+            outDir = new File(outDirPath)
+            if (!outDir.isDirectory()) {
+                if (verbose) log.lifecycle "Create outDir: ${outDir.absolutePath}"
+                outDir.mkdirs()
+            }
+        }
+
+        /*def repla = src.absolutePath.replaceAll(srcDir.absolutePath, "")
+        println "replaced: ${repla}"
+        def dirPath = outDir.absolutePath + repla.replaceAll(src.name, "")
+        println "save to dir: ${dirPath}"
+        def tmpOutJasperDir = new File(dirPath)
+        if (tmpOutJasperDir.isDirectory()) {
+            println 'Directory already exsits'
+        } else {
+            tmpOutJasperDir.mkdirs()
+        }
+        */
+
+        //new File(tmpOutJasperDir, src.name.replaceAll(srcExt, outExt))
+        new File(outDir, src.name.replaceAll(srcExt, outExt))
+        //new File(outDir, repla.replaceAll(srcExt, outExt))
+    }
+
+    def failureMessage = { List failures ->
+        def stringBuilder = new StringBuilder()
+        stringBuilder.append "Could not compile ${failures.size()} designs:\n"
+        failures.each { failure ->
+            stringBuilder.append "\t[${failure['name']}] ${failure['exception'].message}\n"
+        }
+        stringBuilder.toString()
+    }
 
 }

--- a/src/main/groovy/com/github/gmazelier/tasks/JasperReportsCompile.groovy
+++ b/src/main/groovy/com/github/gmazelier/tasks/JasperReportsCompile.groovy
@@ -21,7 +21,7 @@ class JasperReportsCompile extends DefaultTask {
     @Input
     def String outExt
     def boolean verbose
-    def boolean usePackageDir
+    def boolean useRelativeOutDir
     def log = getLogger()
 
     @TaskAction
@@ -80,7 +80,7 @@ class JasperReportsCompile extends DefaultTask {
 
     def File outputFile(File src) {
 
-        if (usePackageDir) {
+        if (useRelativeOutDir) {
             def srcPackagePath = src.absolutePath.replaceAll(srcDir.absolutePath, "")
             def outDirPath = outDir.absolutePath + srcPackagePath.replaceAll(src.name, "")
             outDir = new File(outDirPath)
@@ -90,21 +90,8 @@ class JasperReportsCompile extends DefaultTask {
             }
         }
 
-        /*def repla = src.absolutePath.replaceAll(srcDir.absolutePath, "")
-        println "replaced: ${repla}"
-        def dirPath = outDir.absolutePath + repla.replaceAll(src.name, "")
-        println "save to dir: ${dirPath}"
-        def tmpOutJasperDir = new File(dirPath)
-        if (tmpOutJasperDir.isDirectory()) {
-            println 'Directory already exsits'
-        } else {
-            tmpOutJasperDir.mkdirs()
-        }
-        */
-
-        //new File(tmpOutJasperDir, src.name.replaceAll(srcExt, outExt))
         new File(outDir, src.name.replaceAll(srcExt, outExt))
-        //new File(outDir, repla.replaceAll(srcExt, outExt))
+
     }
 
     def failureMessage = { List failures ->

--- a/src/main/groovy/com/github/gmazelier/tasks/JasperReportsPreCompile.groovy
+++ b/src/main/groovy/com/github/gmazelier/tasks/JasperReportsPreCompile.groovy
@@ -20,7 +20,7 @@ class JasperReportsPreCompile extends DefaultTask {
     def boolean keepJava
     def boolean validateXml
     def boolean verbose
-    def boolean usePackageDir
+    def boolean useRelativeOutDir
 
     @TaskAction
     void prepareCompilation() {
@@ -83,7 +83,7 @@ class JasperReportsPreCompile extends DefaultTask {
             lifecycle "Compiler: ${compiler}"
             lifecycle "Keep Java files: ${keepJava}"
             lifecycle "Validate XML before compiling: ${validateXml}"
-            lifecycle "Use Java package dir: ${usePackageDir}"
+            lifecycle "Use relativ outDir: ${useRelativeOutDir}"
             lifecycle "<<<"
         }
     }

--- a/src/main/groovy/com/github/gmazelier/tasks/JasperReportsPreCompile.groovy
+++ b/src/main/groovy/com/github/gmazelier/tasks/JasperReportsPreCompile.groovy
@@ -1,6 +1,4 @@
 package com.github.gmazelier.tasks
-import static net.sf.jasperreports.engine.design.JRCompiler.*
-import static net.sf.jasperreports.engine.xml.JRReportSaxParserFactory.COMPILER_XML_VALIDATION
 
 import net.sf.jasperreports.engine.DefaultJasperReportsContext
 import net.sf.jasperreports.engine.JasperReportsContext
@@ -8,81 +6,86 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.tasks.TaskAction
 
+import static net.sf.jasperreports.engine.design.JRCompiler.*
+import static net.sf.jasperreports.engine.xml.JRReportSaxParserFactory.COMPILER_XML_VALIDATION
+
 class JasperReportsPreCompile extends DefaultTask {
 
-	def File srcDir
-	def File tmpDir
-	def File outDir
-	def String srcExt
-	def String outExt
-	def String compiler
-	def boolean keepJava
-	def boolean validateXml
-	def boolean verbose
+    def File srcDir
+    def File tmpDir
+    def File outDir
+    def String srcExt
+    def String outExt
+    def String compiler
+    def boolean keepJava
+    def boolean validateXml
+    def boolean verbose
+    def boolean usePackageDir
 
-	@TaskAction
-	void prepareCompilation() {
-		checkDirectories()
-		configureJasperReportsContext()
-		displayConfiguration()
-	}
+    @TaskAction
+    void prepareCompilation() {
+        checkDirectories()
+        configureJasperReportsContext()
+        displayConfiguration()
+    }
 
-	void checkDirectories() {
-		def Map<File,String> directoryErrors = [
-				(srcDir): false,
-				(tmpDir): true,
-				(outDir): true,
-		].collect { directory, isOutputDirectory ->
-			checkDirectory directory, isOutputDirectory
-		}.collectEntries().findAll { it.value }
+    void checkDirectories() {
+        def Map<File, String> directoryErrors = [
+                (srcDir): false,
+                (tmpDir): true,
+                (outDir): true,
+        ].collect { directory, isOutputDirectory ->
+            checkDirectory directory, isOutputDirectory
+        }.collectEntries().findAll { it.value }
 
-		if (directoryErrors) {
-			def message = directoryErrors.collect { directory, errorMessage ->
-				"${directory?.canonicalPath}: $errorMessage"
-			}.join ', '
-			throw new InvalidUserDataException(message)
-		}
-	}
+        if (directoryErrors) {
+            def message = directoryErrors.collect { directory, errorMessage ->
+                "${directory?.canonicalPath}: $errorMessage"
+            }.join ', '
+            throw new InvalidUserDataException(message)
+        }
+    }
 
-	void configureJasperReportsContext() {
-		JasperReportsContext context = DefaultJasperReportsContext.getInstance()
-		context.setProperty COMPILER_XML_VALIDATION, String.valueOf(validateXml)
-		context.setProperty COMPILER_PREFIX, compiler
-		context.setProperty COMPILER_KEEP_JAVA_FILE, String.valueOf(keepJava)
-		context.setProperty COMPILER_TEMP_DIR, tmpDir.canonicalPath
-	}
+    void configureJasperReportsContext() {
+        JasperReportsContext context = DefaultJasperReportsContext.getInstance()
+        context.setProperty COMPILER_XML_VALIDATION, String.valueOf(validateXml)
+        context.setProperty COMPILER_PREFIX, compiler
+        context.setProperty COMPILER_KEEP_JAVA_FILE, String.valueOf(keepJava)
+        context.setProperty COMPILER_TEMP_DIR, tmpDir.canonicalPath
+    }
 
-	def checkDirectory = { directory, isOutputDirectory ->
-		// If exists, it must be a directory
-		if (directory?.exists() && !directory.isDirectory())
-			return [directory, "${directory} is not a directory!"]
+    def checkDirectory = { directory, isOutputDirectory ->
+        // If exists, it must be a directory
+        if (directory?.exists() && !directory.isDirectory())
+            return [directory, "${directory} is not a directory!"]
 
-		// If is an output directory and does not exist, create it
-		if (isOutputDirectory && !directory.exists() && !directory.mkdirs())
-			return [directory, "${directory} cannot be create!"]
+        // If is an output directory and does not exist, create it
+        if (isOutputDirectory && !directory.exists() && !directory.mkdirs())
+            return [directory, "${directory} cannot be create!"]
 
-		// If is an output directory, it must be writable
-		if (isOutputDirectory && !directory.canWrite())
-			return [directory, "${directory} is not writeable!"]
+        // If is an output directory, it must be writable
+        if (isOutputDirectory && !directory.canWrite())
+            return [directory, "${directory} is not writeable!"]
 
-		[directory, null]
-	}
+        [directory, null]
+    }
 
-	void displayConfiguration() {
-		if (!verbose) return
+    void displayConfiguration() {
+        if (!verbose) return
 
-		getLogger().with {
-			lifecycle ">>> JasperReports Plugin Configuration"
-			lifecycle "Source directory: ${srcDir.canonicalPath}"
-			lifecycle "Temporary directory: ${tmpDir.canonicalPath}"
-			lifecycle "Output directory: ${outDir.canonicalPath}"
-			lifecycle "Source files extension: ${srcExt}"
-			lifecycle "Compiled files extension: ${outExt}"
-			lifecycle "Compiler: ${compiler}"
-			lifecycle "Keep Java files: ${keepJava}"
-			lifecycle "Validate XML before compiling: ${validateXml}"
-			lifecycle "<<<"
-		}
-	}
+        getLogger().with {
+            lifecycle ">>> JasperReports Plugin Configuration"
+            lifecycle "Source directory: ${srcDir.canonicalPath}"
+            lifecycle "Temporary directory: ${tmpDir.canonicalPath}"
+            lifecycle "Output directory: ${outDir.canonicalPath}"
+            lifecycle "Source files extension: ${srcExt}"
+            lifecycle "Compiled files extension: ${outExt}"
+            lifecycle "Compiler: ${compiler}"
+            lifecycle "Keep Java files: ${keepJava}"
+            lifecycle "Validate XML before compiling: ${validateXml}"
+            lifecycle "Use Java package dir: ${usePackageDir}"
+            lifecycle "<<<"
+        }
+    }
 
 }

--- a/src/main/groovy/com/github/gmazelier/tasks/JasperReportsPreCompile.groovy
+++ b/src/main/groovy/com/github/gmazelier/tasks/JasperReportsPreCompile.groovy
@@ -11,81 +11,80 @@ import static net.sf.jasperreports.engine.xml.JRReportSaxParserFactory.COMPILER_
 
 class JasperReportsPreCompile extends DefaultTask {
 
-    def File srcDir
-    def File tmpDir
-    def File outDir
-    def String srcExt
-    def String outExt
-    def String compiler
-    def boolean keepJava
-    def boolean validateXml
-    def boolean verbose
-    def boolean useRelativeOutDir
+	def File srcDir
+	def File tmpDir
+	def File outDir
+	def String srcExt
+	def String outExt
+	def String compiler
+	def boolean keepJava
+	def boolean validateXml
+	def boolean verbose
+	def boolean useRelativeOutDir
 
-    @TaskAction
-    void prepareCompilation() {
-        checkDirectories()
-        configureJasperReportsContext()
-        displayConfiguration()
-    }
+	@TaskAction
+	void prepareCompilation() {
+		checkDirectories()
+		configureJasperReportsContext()
+		displayConfiguration()
+	}
 
-    void checkDirectories() {
-        def Map<File, String> directoryErrors = [
-                (srcDir): false,
-                (tmpDir): true,
-                (outDir): true,
-        ].collect { directory, isOutputDirectory ->
-            checkDirectory directory, isOutputDirectory
-        }.collectEntries().findAll { it.value }
+	void checkDirectories() {
+		def Map<File, String> directoryErrors = [
+			(srcDir): false,
+			(tmpDir): true,
+			(outDir): true,
+		].collect { directory, isOutputDirectory ->
+			checkDirectory directory, isOutputDirectory
+		}.collectEntries().findAll { it.value }
 
-        if (directoryErrors) {
-            def message = directoryErrors.collect { directory, errorMessage ->
-                "${directory?.canonicalPath}: $errorMessage"
-            }.join ', '
-            throw new InvalidUserDataException(message)
-        }
-    }
+		if (directoryErrors) {
+			def message = directoryErrors.collect { directory, errorMessage ->
+				"${directory?.canonicalPath}: $errorMessage"
+			}.join ', '
+			throw new InvalidUserDataException(message)
+		}
+	}
 
-    void configureJasperReportsContext() {
-        JasperReportsContext context = DefaultJasperReportsContext.getInstance()
-        context.setProperty COMPILER_XML_VALIDATION, String.valueOf(validateXml)
-        context.setProperty COMPILER_PREFIX, compiler
-        context.setProperty COMPILER_KEEP_JAVA_FILE, String.valueOf(keepJava)
-        context.setProperty COMPILER_TEMP_DIR, tmpDir.canonicalPath
-    }
+	void configureJasperReportsContext() {
+		JasperReportsContext context = DefaultJasperReportsContext.getInstance()
+		context.setProperty COMPILER_XML_VALIDATION, String.valueOf(validateXml)
+		context.setProperty COMPILER_PREFIX, compiler
+		context.setProperty COMPILER_KEEP_JAVA_FILE, String.valueOf(keepJava)
+		context.setProperty COMPILER_TEMP_DIR, tmpDir.canonicalPath
+	}
 
-    def checkDirectory = { directory, isOutputDirectory ->
-        // If exists, it must be a directory
-        if (directory?.exists() && !directory.isDirectory())
-            return [directory, "${directory} is not a directory!"]
+	def checkDirectory = { directory, isOutputDirectory ->
+		// If exists, it must be a directory
+		if (directory?.exists() && !directory.isDirectory())
+			return [directory, "${directory} is not a directory!"]
 
-        // If is an output directory and does not exist, create it
-        if (isOutputDirectory && !directory.exists() && !directory.mkdirs())
-            return [directory, "${directory} cannot be create!"]
+		// If is an output directory and does not exist, create it
+		if (isOutputDirectory && !directory.exists() && !directory.mkdirs())
+			return [directory, "${directory} cannot be create!"]
 
-        // If is an output directory, it must be writable
-        if (isOutputDirectory && !directory.canWrite())
-            return [directory, "${directory} is not writeable!"]
+		// If is an output directory, it must be writable
+		if (isOutputDirectory && !directory.canWrite())
+			return [directory, "${directory} is not writeable!"]
 
-        [directory, null]
-    }
+		[directory, null]
+	}
 
-    void displayConfiguration() {
-        if (!verbose) return
+	void displayConfiguration() {
+		if (!verbose) return
 
-        getLogger().with {
-            lifecycle ">>> JasperReports Plugin Configuration"
-            lifecycle "Source directory: ${srcDir.canonicalPath}"
-            lifecycle "Temporary directory: ${tmpDir.canonicalPath}"
-            lifecycle "Output directory: ${outDir.canonicalPath}"
-            lifecycle "Source files extension: ${srcExt}"
-            lifecycle "Compiled files extension: ${outExt}"
-            lifecycle "Compiler: ${compiler}"
-            lifecycle "Keep Java files: ${keepJava}"
-            lifecycle "Validate XML before compiling: ${validateXml}"
-            lifecycle "Use relativ outDir: ${useRelativeOutDir}"
-            lifecycle "<<<"
-        }
-    }
-
+		getLogger().with {
+			lifecycle ">>> JasperReports Plugin Configuration"
+			lifecycle "Source directory: ${srcDir.canonicalPath}"
+			lifecycle "Temporary directory: ${tmpDir.canonicalPath}"
+			lifecycle "Output directory: ${outDir.canonicalPath}"
+			lifecycle "Source files extension: ${srcExt}"
+			lifecycle "Compiled files extension: ${outExt}"
+			lifecycle "Compiler: ${compiler}"
+			lifecycle "Keep Java files: ${keepJava}"
+			lifecycle "Validate XML before compiling: ${validateXml}"
+			lifecycle "Use relativ outDir: ${useRelativeOutDir}"
+			lifecycle "<<<"
+		}
+	}
 }

--- a/src/test/groovy/com/github/gmazelier/plugins/JasperReportsPluginTest.groovy
+++ b/src/test/groovy/com/github/gmazelier/plugins/JasperReportsPluginTest.groovy
@@ -49,7 +49,7 @@ class JasperReportsPluginTest extends GroovyTestCase {
         assert !jasperreports.keepJava
         assert jasperreports.validateXml
         assert !jasperreports.verbose
-        assert !jasperreports.usePackageDir
+        assert !jasperreports.useRelativeOutDir
     }
 
 }

--- a/src/test/groovy/com/github/gmazelier/plugins/JasperReportsPluginTest.groovy
+++ b/src/test/groovy/com/github/gmazelier/plugins/JasperReportsPluginTest.groovy
@@ -7,49 +7,48 @@ import org.gradle.testfixtures.ProjectBuilder
 
 class JasperReportsPluginTest extends GroovyTestCase {
 
-    public void testPluginAddsJasperReportsPreCompileTask() {
-        Project project = ProjectBuilder.builder().build()
-        project.apply plugin: 'com.github.gmazelier.jasperreports'
+	public void testPluginAddsJasperReportsPreCompileTask() {
+		Project project = ProjectBuilder.builder().build()
+		project.apply plugin: 'com.github.gmazelier.jasperreports'
 
-        assert project.tasks.prepareReportsCompilation instanceof JasperReportsPreCompile
+		assert project.tasks.prepareReportsCompilation instanceof JasperReportsPreCompile
     }
 
-    public void testPluginAddsJasperReportsCompileTask() {
-        Project project = ProjectBuilder.builder().build()
-        project.apply plugin: 'com.github.gmazelier.jasperreports'
+	public void testPluginAddsJasperReportsCompileTask() {
+		Project project = ProjectBuilder.builder().build()
+		project.apply plugin: 'com.github.gmazelier.jasperreports'
 
-        assert project.tasks.compileAllReports instanceof JasperReportsCompile
-    }
+		assert project.tasks.compileAllReports instanceof JasperReportsCompile
+	}
 
-    public void testCompileAllReportsDependsOnPrepareReportsCompilation() {
-        Project project = ProjectBuilder.builder().build()
-        project.apply plugin: 'com.github.gmazelier.jasperreports'
+	public void testCompileAllReportsDependsOnPrepareReportsCompilation() {
+		Project project = ProjectBuilder.builder().build()
+		project.apply plugin: 'com.github.gmazelier.jasperreports'
 
-        assert project.tasks.compileAllReports.dependsOn(project.tasks.prepareReportsCompilation)
-    }
+		assert project.tasks.compileAllReports.dependsOn(project.tasks.prepareReportsCompilation)
+	}
 
-    public void testPluginAddsJasperReportsExtension() {
-        Project project = ProjectBuilder.builder().build()
-        project.apply plugin: 'com.github.gmazelier.jasperreports'
+	public void testPluginAddsJasperReportsExtension() {
+		Project project = ProjectBuilder.builder().build()
+		project.apply plugin: 'com.github.gmazelier.jasperreports'
 
-        assert project.jasperreports instanceof JasperReportsExtension
-    }
+		assert project.jasperreports instanceof JasperReportsExtension
+	}
 
-    public void testPluginHasDefaultValues() {
-        Project project = ProjectBuilder.builder().build()
-        project.apply plugin: 'com.github.gmazelier.jasperreports'
+	public void testPluginHasDefaultValues() {
+		Project project = ProjectBuilder.builder().build()
+		project.apply plugin: 'com.github.gmazelier.jasperreports'
 
-        def jasperreports = project.jasperreports as JasperReportsExtension
-        assert jasperreports.srcDir == new File('src/main/jasperreports')
-        assert jasperreports.tmpDir == new File("${project.buildDir}/jasperreports")
-        assert jasperreports.outDir == new File("${project.buildDir}/classes/main")
-        assert jasperreports.srcExt == '.jrxml'
-        assert jasperreports.outExt == '.jasper'
-        assert jasperreports.compiler == 'net.sf.jasperreports.engine.design.JRJdtCompiler'
-        assert !jasperreports.keepJava
-        assert jasperreports.validateXml
-        assert !jasperreports.verbose
-        assert !jasperreports.useRelativeOutDir
-    }
-
+		def jasperreports = project.jasperreports as JasperReportsExtension
+		assert jasperreports.srcDir == new File('src/main/jasperreports')
+		assert jasperreports.tmpDir == new File("${project.buildDir}/jasperreports")
+		assert jasperreports.outDir == new File("${project.buildDir}/classes/main")
+		assert jasperreports.srcExt == '.jrxml'
+		assert jasperreports.outExt == '.jasper'
+		assert jasperreports.compiler == 'net.sf.jasperreports.engine.design.JRJdtCompiler'
+		assert !jasperreports.keepJava
+		assert jasperreports.validateXml
+		assert !jasperreports.verbose
+		assert !jasperreports.useRelativeOutDir
+	}
 }

--- a/src/test/groovy/com/github/gmazelier/plugins/JasperReportsPluginTest.groovy
+++ b/src/test/groovy/com/github/gmazelier/plugins/JasperReportsPluginTest.groovy
@@ -7,48 +7,49 @@ import org.gradle.testfixtures.ProjectBuilder
 
 class JasperReportsPluginTest extends GroovyTestCase {
 
-	public void testPluginAddsJasperReportsPreCompileTask() {
-		Project project = ProjectBuilder.builder().build()
-		project.apply plugin: 'com.github.gmazelier.jasperreports'
+    public void testPluginAddsJasperReportsPreCompileTask() {
+        Project project = ProjectBuilder.builder().build()
+        project.apply plugin: 'com.github.gmazelier.jasperreports'
 
-		assert project.tasks.prepareReportsCompilation instanceof JasperReportsPreCompile
-	}
+        assert project.tasks.prepareReportsCompilation instanceof JasperReportsPreCompile
+    }
 
-	public void testPluginAddsJasperReportsCompileTask() {
-		Project project = ProjectBuilder.builder().build()
-		project.apply plugin: 'com.github.gmazelier.jasperreports'
+    public void testPluginAddsJasperReportsCompileTask() {
+        Project project = ProjectBuilder.builder().build()
+        project.apply plugin: 'com.github.gmazelier.jasperreports'
 
-		assert project.tasks.compileAllReports instanceof JasperReportsCompile
-	}
+        assert project.tasks.compileAllReports instanceof JasperReportsCompile
+    }
 
-	public void testCompileAllReportsDependsOnPrepareReportsCompilation() {
-		Project project = ProjectBuilder.builder().build()
-		project.apply plugin: 'com.github.gmazelier.jasperreports'
+    public void testCompileAllReportsDependsOnPrepareReportsCompilation() {
+        Project project = ProjectBuilder.builder().build()
+        project.apply plugin: 'com.github.gmazelier.jasperreports'
 
-		assert project.tasks.compileAllReports.dependsOn(project.tasks.prepareReportsCompilation)
-	}
+        assert project.tasks.compileAllReports.dependsOn(project.tasks.prepareReportsCompilation)
+    }
 
-	public void testPluginAddsJasperReportsExtension() {
-		Project project = ProjectBuilder.builder().build()
-		project.apply plugin: 'com.github.gmazelier.jasperreports'
+    public void testPluginAddsJasperReportsExtension() {
+        Project project = ProjectBuilder.builder().build()
+        project.apply plugin: 'com.github.gmazelier.jasperreports'
 
-		assert project.jasperreports instanceof JasperReportsExtension
-	}
+        assert project.jasperreports instanceof JasperReportsExtension
+    }
 
-	public void testPluginHasDefaultValues() {
-		Project project = ProjectBuilder.builder().build()
-		project.apply plugin: 'com.github.gmazelier.jasperreports'
+    public void testPluginHasDefaultValues() {
+        Project project = ProjectBuilder.builder().build()
+        project.apply plugin: 'com.github.gmazelier.jasperreports'
 
-		def jasperreports = project.jasperreports as JasperReportsExtension
-		assert jasperreports.srcDir == new File('src/main/jasperreports')
-		assert jasperreports.tmpDir == new File("${project.buildDir }/jasperreports")
-		assert jasperreports.outDir == new File("${project.buildDir }/classes/main")
-		assert jasperreports.srcExt == '.jrxml'
-		assert jasperreports.outExt == '.jasper'
-		assert jasperreports.compiler == 'net.sf.jasperreports.engine.design.JRJdtCompiler'
-		assert !jasperreports.keepJava
-		assert jasperreports.validateXml
-		assert !jasperreports.verbose
-	}
+        def jasperreports = project.jasperreports as JasperReportsExtension
+        assert jasperreports.srcDir == new File('src/main/jasperreports')
+        assert jasperreports.tmpDir == new File("${project.buildDir}/jasperreports")
+        assert jasperreports.outDir == new File("${project.buildDir}/classes/main")
+        assert jasperreports.srcExt == '.jrxml'
+        assert jasperreports.outExt == '.jasper'
+        assert jasperreports.compiler == 'net.sf.jasperreports.engine.design.JRJdtCompiler'
+        assert !jasperreports.keepJava
+        assert jasperreports.validateXml
+        assert !jasperreports.verbose
+        assert !jasperreports.usePackageDir
+    }
 
 }


### PR DESCRIPTION
Hey,
your plugin is really nice but for my company we have a different project structure. So we can't use your plugin out of the box.
Because of it i added a new parameter 'useRelativeOutDir'. If you set the parameter to true the output dir is relative to java classpath.

For example our project structure is:
com.rankec.jaspertest.report.jrxml
Then the output dir is: ${project.buildDir}/classes/main/com/rankec/jaspertest/report.jasper

atm the default is just: ${project.buildDir}/classes/main/report.jasper

I hope you will merge it and maybe release it as 0.2.1 :)

Best regards
