### PR TITLE
Change Maven repo for dependencies to a working one

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ repositories {
 	jcenter()
 	mavenCentral()
 	maven {
-		url 'http://jaspersoft.artifactoryonline.com/jaspersoft/third-party-ce-artifacts/'
+		url 'https://jaspersoft.jfrog.io/jaspersoft/third-party-ce-artifacts/'
 	}
 }
 


### PR DESCRIPTION
The current Maven repo for dependencies does not work anymore. This PR changes it to a working repo.